### PR TITLE
Enable the option to perform peek and pop on search results

### DIFF
--- a/Sanntidsappen/ViewControllers/Departure/DepartureSearchResultViewController.swift
+++ b/Sanntidsappen/ViewControllers/Departure/DepartureSearchResultViewController.swift
@@ -13,6 +13,8 @@ import CoreLocation
 protocol DepartureSearchResultViewControllerDelegate: class {
     func dismissKeyboardFrom(_ viewController: DepartureSearchResultViewController)
     func selectDepartureAtIndexPath(_ viewController: DepartureSearchResultViewController, at indexPath: IndexPath)
+    func previewDepartureAtIndexPath(_ viewController: DepartureSearchResultViewController, at indexPath: IndexPath) -> DepartureDetailsViewController?
+    func commitPreviewedViewController(_ viewController: DepartureSearchResultViewController, viewControllerToCommit: DepartureDetailsViewController)
 }
 
 class DepartureSearchResultViewController: UIViewController {
@@ -47,6 +49,8 @@ class DepartureSearchResultViewController: UIViewController {
         collectionView.alwaysBounceVertical = true
 
         collectionView.register(DepartureSearchResultCollectionViewCell.self, forCellWithReuseIdentifier: DepartureSearchResultCollectionViewCell.identifier)
+        
+        registerForPreviewing(with: self, sourceView: collectionView)
 
         view.addSubview(collectionView)
 
@@ -82,6 +86,27 @@ extension DepartureSearchResultViewController: UICollectionViewDelegate {
     }
 
 }
+
+// MARK: UIViewControllerPreviewingDelegate
+
+extension DepartureSearchResultViewController: UIViewControllerPreviewingDelegate {
+    
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        self.delegate?.commitPreviewedViewController(self, viewControllerToCommit: viewControllerToCommit as! DepartureDetailsViewController)
+    }
+    
+    
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        if let indexPath = collectionView.indexPathForItem(at: location), let cellAttributes = collectionView.layoutAttributesForItem(at: indexPath) {
+            previewingContext.sourceRect = cellAttributes.frame
+            return self.delegate?.previewDepartureAtIndexPath(self, at: indexPath)
+        }
+        
+        return nil
+    }
+    
+}
+
 
 
 // MARK: - DataSource

--- a/Sanntidsappen/ViewControllers/Departure/DepartureViewController.swift
+++ b/Sanntidsappen/ViewControllers/Departure/DepartureViewController.swift
@@ -282,7 +282,6 @@ extension DepartureViewController: UIViewControllerPreviewingDelegate {
         self.delegate?.moveToDetailsViewController(from: self, withDetailsView: viewControllerToCommit as! DepartureDetailsViewController)
     }
     
-    
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         if let indexPath = collectionView.indexPathForItem(at: location), let cellAttributes = collectionView.layoutAttributesForItem(at: indexPath) {
             if indexPath.section > 0 {
@@ -295,7 +294,6 @@ extension DepartureViewController: UIViewControllerPreviewingDelegate {
     }
 
 }
-
 
 // MARK: CLLocationManager
 
@@ -325,7 +323,22 @@ extension DepartureViewController: CLLocationManagerDelegate {
 // MARK: DepartureSearchResultViewControllerDelegate
 
 extension DepartureViewController: DepartureSearchResultViewControllerDelegate {
-
+    
+    func previewDepartureAtIndexPath(_ viewController: DepartureSearchResultViewController, at indexPath: IndexPath) -> DepartureDetailsViewController? {
+        let stop = searchResultController.stops[indexPath.item]
+        return self.delegate?.getDetailsViewController(forStop: stop)
+    }
+    
+    func commitPreviewedViewController(_ viewController: DepartureSearchResultViewController, viewControllerToCommit: DepartureDetailsViewController) {
+        
+        RecentStopSearchData.shared.saveSearchToCoreData(stop: viewControllerToCommit.stop) { stops in
+            self.recentStopSearch = stops
+            self.collectionView.reloadData()
+        }
+        
+        self.delegate?.moveToDetailsViewController(from: self, withDetailsView: viewControllerToCommit)
+    }
+    
     func selectDepartureAtIndexPath(_ viewController: DepartureSearchResultViewController, at indexPath: IndexPath) {
         let stop = searchResultController.stops[indexPath.item]
 
@@ -340,5 +353,5 @@ extension DepartureViewController: DepartureSearchResultViewControllerDelegate {
     func dismissKeyboardFrom(_ viewController: DepartureSearchResultViewController) {
         self.searchController.searchBar.resignFirstResponder()
     }
-
+    
 }


### PR DESCRIPTION
Since the last one was accepted I try again with this one. Exactly the same feature as last time, but now from `DepartureSearchResultViewController` onto `DepartureDetailsViewController`. 

One thing I'm wondering about is wether the code for updating recent search should be extracted, since the exact same thing is happening in `selectDepartureAtIndexPath` and now `commitPreviewedViewController`.  Or is it okay to repeat ourself here?

![simulator screen shot - iphone xs - 2018-11-27 at 15 49 44](https://user-images.githubusercontent.com/3852639/49089666-56aea800-f25c-11e8-8ff2-61d6641a273c.png)
![simulator screen shot - iphone xs - 2018-11-27 at 15 49 48](https://user-images.githubusercontent.com/3852639/49089675-5b735c00-f25c-11e8-9b92-0be58bb2e451.png)
